### PR TITLE
Replace description of the sitemap

### DIFF
--- a/md/md-sitemap.php
+++ b/md/md-sitemap.php
@@ -54,7 +54,7 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="generator" content="markdown-CMS" />
-        <meta name="description" content="The website index for Tek Eye. Lists all the articles and pages available on Tek Eye UK. A useful page to find an article in a given category, for example Android or computing." />
+        <meta name="description" content="The website index for <?php echo $MD_SETTINGS['SITE_NAME']; ?>" />
         <?php
             //Set title
             echo "<title>Index | ".$MD_SETTINGS['SITE_NAME']."</title>\n";


### PR DESCRIPTION
Replace the Tek Eye site description meta tag with a more generic one that includes the site name from the configuration file.